### PR TITLE
T4ParameterValues Support

### DIFF
--- a/T4.Build/.gitignore
+++ b/T4.Build/.gitignore
@@ -1,0 +1,2 @@
+# Ignore any immediate `tools` directories, as they are likely someone building and testing locally from another project
+/tools/*

--- a/T4.Build/build/common.targets
+++ b/T4.Build/build/common.targets
@@ -31,10 +31,24 @@
         </ItemGroup>
     </Target>
 
-    <Target Name="TextTemplateTransform" DependsOnTargets="TextTemplateCreateTransformList">
+    <Target Name="TextTemplateCreateParameterValueList" Inputs="@(T4ParameterValues)" Outputs="%(T4ParameterValues.Identity)">
+        <PropertyGroup>
+            <T4Build_ParameterIdentity>%(T4ParameterValues.Identity)</T4Build_ParameterIdentity>
+            <T4Build_ParameterValue>%(T4ParameterValues.Value)</T4Build_ParameterValue>
+        </PropertyGroup>
+        <PropertyGroup>
+            <T4Build_ParameterValue>$(T4Build_ParameterValue.Replace('"', '""'))</T4Build_ParameterValue>
+        </PropertyGroup>
+        <ItemGroup>
+            <T4Build_ParameterValueList Include="--variable &quot;$(T4Build_ParameterIdentity)=$(T4Build_ParameterValue)&quot;" Condition="!$([System.String]::IsNullOrWhiteSpace('$(T4Build_ParameterIdentity)'))" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="TextTemplateTransform" DependsOnTargets="TextTemplateCreateTransformList;TextTemplateCreateParameterValueList">
         <ItemGroup>
             <T4Build_TransformOptions Include="--skip-up-to-date" Condition=" '$(TextTemplateTransformSkipUpToDate)' == 'true' " />
             <T4Build_TransformOptions Include="--parallel" Condition=" '$(TextTemplateTransformParallel)' == 'true' " />
+            <T4Build_TransformOptions Include="@(T4Build_ParameterValueList, ' ')" />
         </ItemGroup>
         <Exec Command="$(T4Build_Command) transform @(T4Build_TransformOptions, ' ') @(T4Build_TransformFiles, ' ')" Condition=" '@(T4Build_TransformFiles)' != '' " ConsoleToMSBuild="true" StandardOutputImportance="normal">
             <Output TaskParameter="ConsoleOutput" ItemName="T4Build_GeneratedFiles" />

--- a/T4.Build/build/common.targets
+++ b/T4.Build/build/common.targets
@@ -22,7 +22,7 @@
 
     <Target Name="TextTemplateCreateTransformList">
         <ItemGroup>
-            <T4Build_TransformFiles Include="@(None)" Condition=" '%(None.Generator)' == 'TextTemplatingFileGenerator' " />
+            <T4Build_TransformFiles Include="@(Compile);@(None);@(Content);@(EmbeddedResource)" Condition=" '%(*.Generator)' == 'TextTemplatingFileGenerator' " />
             <T4Build_TransformFiles Include="@(TextTemplateTransformFiles)" />
         </ItemGroup>
         <ItemGroup Condition=" '$(TextTemplateTransformAll)' == 'true' ">


### PR DESCRIPTION
### Reason for PR

Wanting to move a project over from MSBuild.Full and `Microsoft.TextTemplating`, but needed to use `T4ParameterValues`.

### Outline of key changes

- Added support to `T4.Build` to take in one or many `--variable` arguments, using `"Include=Value"` format.
- Added processing of passed in variables into a read-only dictionary.
- Updated `BuildTemplateGenerator` to enable support for a preprocessing `Func<>`, which is called between input file validation, and processing of template content.
    - _**[Note]**_ Due to accessibility restrictions of some of the `TemplateGenerator` methods, I had to pull that code into this class. Ideally, `TemplateGenerator` could expose these as `protected`/`virtual`, so that they can be overridden by implementers.
- Added a guarded `StringBuilder` for preprocessing replacement (reduced allocations) so that we don't load up a `StringBuilder`, and then have it generate the same string, if there are no variables to replace.

### Ancillary changes

- `build/common.targets`
    - Increased the scope of `Item` types to search for transform files; better aligns with `Microsoft.TextTemplating` MSBuild.
        - `Microsoft.TextTemplating.targets` uses the exact list as added, and I was working on a separate project where the TT file was added as `Content`, not `None`. Given that the same `Generator` guard is used, this seemed safe.
- `T4.Build/.gitignore`
    - Added T4.Build project-specific gitignore, which ignores any `T4.Build/tools/*` files.
        - I was using a `Reference` and direct `Import` from another project to test and use these changes, and needed to directory junction `T4.Build/tools/` to `T4.Build\bin\Debug\netcoreapp3.1\` so that the import/targets pathing aligned. Can remove if you don't like it.