### PR TITLE
fix bug where paths with spaces cause errors on build

### DIFF
--- a/T4.Build/build/common.targets
+++ b/T4.Build/build/common.targets
@@ -36,7 +36,7 @@
             <T4Build_TransformOptions Include="--skip-up-to-date" Condition=" '$(TextTemplateTransformSkipUpToDate)' == 'true' " />
             <T4Build_TransformOptions Include="--parallel" Condition=" '$(TextTemplateTransformParallel)' == 'true' " />
         </ItemGroup>
-        <Exec Command="$(T4Build_Command) transform @(T4Build_TransformOptions, ' ') @(T4Build_TransformFiles, ' ')" Condition=" '@(T4Build_TransformFiles)' != '' " ConsoleToMSBuild="true" StandardOutputImportance="normal">
+        <Exec Command="$(T4Build_Command) transform @(T4Build_TransformOptions, ' ') @(T4Build_TransformFiles->'&quot;%(Identity)&quot;', ' ')" Condition=" '@(T4Build_TransformFiles)' != '' " ConsoleToMSBuild="true" StandardOutputImportance="normal">
             <Output TaskParameter="ConsoleOutput" ItemName="T4Build_GeneratedFiles" />
         </Exec>
         <ItemGroup>
@@ -46,7 +46,7 @@
     </Target>
 
     <Target Name="TextTemplateClean" DependsOnTargets="TextTemplateCreateTransformList">
-        <Exec Command="$(T4Build_Command) clean @(T4Build_TransformFiles, ' ')" Condition=" '@(T4Build_TransformFiles)' != '' " ConsoleToMSBuild="true" StandardOutputImportance="normal" />
+        <Exec Command="$(T4Build_Command) clean @(T4Build_TransformFiles->'&quot;%(Identity)&quot;', ' ')" Condition=" '@(T4Build_TransformFiles)' != '' " ConsoleToMSBuild="true" StandardOutputImportance="normal" />
     </Target>
 
 </Project>


### PR DESCRIPTION
fixes bug where paths with spaces causes errors at build-time

Resolves #14

## Test Evidence

https://gist.github.com/Pxtl/dc31b38cd2d1d74394a66fe6790851fb

I can now build a t4 template that includes various templates with spaces.

relevant section:

```txt
dotnet exec "C:\Users\zaratem\.nuget\packages\t4.build\0.2.4\build\../tools/T4.Build.dll" clean "Static Text Temp
         late.tt" "TextTemplate Test Withdate.tt" "TextTemplate That Reads File.tt"
```